### PR TITLE
Set current_ to keep invariant in error case

### DIFF
--- a/stenotype/aio.cc
+++ b/stenotype/aio.cc
@@ -188,7 +188,7 @@ Error Output::Rotate(const std::string& dirname, int64_t micros,
   std::string name = HiddenFile(dirname, micros);
   int fd = open(name.c_str(), O_CREAT | O_WRONLY | O_DSYNC | O_DIRECT, 0600);
   LOG(INFO) << "Opening packet file " << name << ": " << fd;
-  RETURN_IF_ERROR(Errno(fd), "open");
+  RETURN_IF_ERROR(Errno(fd), (current_=NULL,"open") );
   if (initial_size > 0) {
     LOG_IF_ERROR(Errno(fallocate(fd, 0, 0, initial_size)), "fallocate");
   }


### PR DESCRIPTION
The very first time output.Rotate() is called, current_ might be uninitialized.  If the open() call fails then, RETURN_IF_ERROR does not set it to a different value.  Later calls in Output::Write() will dereference current_ and crash.